### PR TITLE
Expand frontend retail story and refresh product copy

### DIFF
--- a/frontend/src/components/BusiestRailChart.vue
+++ b/frontend/src/components/BusiestRailChart.vue
@@ -263,8 +263,7 @@ function onEndInput(e: Event) {
     </div>
 
     <div v-if="loadError" class="chart-fallback">
-      <p>This little ranking couldn’t load. Refresh the page, or try again later — the rest of the story still
-        works.</p>
+      <p>Rail load data is unavailable right now. Refresh and try again.</p>
     </div>
 
     <div v-else class="chart-body">

--- a/frontend/src/components/RetailAccessMap.vue
+++ b/frontend/src/components/RetailAccessMap.vue
@@ -1,0 +1,519 @@
+<script setup lang="ts">
+import { computed, onMounted, ref } from 'vue'
+import * as d3 from 'd3'
+
+import type { StoryMediaPreset } from '@/content/productStory'
+import { withBase } from '@/utils/assets'
+
+type MetricMode = 'supermarkets_30min' | 'ikea_60min'
+
+interface StationMetric {
+  station_key: string
+  station_name: string
+  stop_lat: number
+  stop_lon: number
+  supermarkets_30min: number
+  schools_30min: number
+  hospitals_30min: number
+  ikea_60min: number
+  has_ikea_60min: boolean
+}
+
+interface SummaryPayload {
+  departure_time: string
+  station_count: number
+  poi_counts: {
+    schools: number
+    hospitals: number
+    ikea: number
+    supermarkets: number
+  }
+  top_supermarket_station_30min: {
+    station_name: string
+    value: number
+  }
+}
+
+const props = defineProps<{
+  preset: StoryMediaPreset
+}>()
+
+const boundary = ref<object | null>(null)
+const stations = ref<StationMetric[]>([])
+const summary = ref<SummaryPayload | null>(null)
+const loading = ref(true)
+const loadError = ref(false)
+const metricMode = ref<MetricMode>('supermarkets_30min')
+const selectedStationKey = ref('')
+const tooltip = ref({
+  visible: false,
+  x: 0,
+  y: 0,
+  name: '',
+  value: '',
+})
+
+const boundaryUrl = withBase('/data/swiss_boundary_wgs84.geojson')
+const metricsUrl = withBase('/data/story_station_metrics_0800.json')
+const summaryUrl = withBase('/data/story_pois_summary.json')
+
+const showControls = computed(() => props.preset === 'retail-access-playground')
+
+const featuredNames = ['Lausanne', 'Zürich HB', 'Bern', 'Genève', 'Basel SBB']
+
+const projection = computed(() => {
+  if (!boundary.value) {
+    return null
+  }
+  return d3.geoMercator().fitExtent(
+    [[22, 18], [978, 444]],
+    boundary.value as any,
+  )
+})
+
+const boundaryPath = computed(() => {
+  if (!projection.value || !boundary.value) {
+    return ''
+  }
+  return d3.geoPath(projection.value)(boundary.value as any) ?? ''
+})
+
+const featuredStations = computed(() =>
+  featuredNames
+    .map(name => stations.value.find(station => station.station_name === name))
+    .filter((station): station is StationMetric => Boolean(station)),
+)
+
+const selectedStation = computed(
+  () => stations.value.find(station => station.station_key === selectedStationKey.value) ?? featuredStations.value[0] ?? null,
+)
+
+const metricConfig = computed(() => {
+  if (metricMode.value === 'ikea_60min') {
+    return {
+      label: 'IKEA within 60 min',
+      shortLabel: 'IKEA 60 min',
+      max: d3.max(stations.value, station => station.ikea_60min) ?? 1,
+      formatter: (value: number) => `${value} IKEA`,
+      key: 'ikea_60min' as const,
+    }
+  }
+
+  return {
+    label: 'Supermarkets within 30 min',
+    shortLabel: 'Supermarkets 30 min',
+    max: d3.max(stations.value, station => station.supermarkets_30min) ?? 1,
+    formatter: (value: number) => `${value} stores`,
+    key: 'supermarkets_30min' as const,
+  }
+})
+
+const plottedStations = computed(() => {
+  if (!projection.value) {
+    return []
+  }
+
+  return stations.value
+    .map(station => {
+      const projected = projection.value?.([station.stop_lon, station.stop_lat])
+      if (!projected) {
+        return null
+      }
+      const value = station[metricConfig.value.key]
+      return {
+        ...station,
+        value,
+        cx: projected[0],
+        cy: projected[1],
+      }
+    })
+    .filter((station): station is StationMetric & { value: number; cx: number; cy: number } => station !== null)
+})
+
+const selectedValue = computed(() => {
+  if (!selectedStation.value) {
+    return 'N/A'
+  }
+  return metricConfig.value.formatter(selectedStation.value[metricConfig.value.key])
+})
+
+const topStationLabel = computed(() => {
+  if (metricMode.value === 'ikea_60min') {
+    const top = [...stations.value].sort((a, b) => b.ikea_60min - a.ikea_60min)[0]
+    if (!top) {
+      return 'N/A'
+    }
+    return `${top.station_name} · ${top.ikea_60min}`
+  }
+  if (!summary.value) {
+    return 'N/A'
+  }
+  return `${summary.value.top_supermarket_station_30min.station_name} · ${summary.value.top_supermarket_station_30min.value}`
+})
+
+function colorFor(value: number): string {
+  const max = Math.max(metricConfig.value.max, 1)
+  return d3.interpolateYlOrRd(0.14 + (value / max) * 0.78)
+}
+
+function radiusFor(value: number, stationKey: string): number {
+  const base = metricMode.value === 'ikea_60min' ? 1.8 : 1.9
+  const scaled = base + Math.sqrt(Math.max(value, 0)) * (metricMode.value === 'ikea_60min' ? 0.48 : 0.34)
+  return selectedStationKey.value === stationKey ? scaled + 1.3 : scaled
+}
+
+function selectStation(stationKey: string) {
+  selectedStationKey.value = stationKey
+}
+
+function selectMetric(nextMetric: MetricMode) {
+  metricMode.value = nextMetric
+}
+
+function showTooltip(event: MouseEvent, station: StationMetric & { value: number }) {
+  tooltip.value = {
+    visible: true,
+    x: event.clientX + 14,
+    y: event.clientY - 16,
+    name: station.station_name,
+    value: metricConfig.value.formatter(station.value),
+  }
+}
+
+function moveTooltip(event: MouseEvent) {
+  tooltip.value.x = event.clientX + 14
+  tooltip.value.y = event.clientY - 16
+}
+
+function hideTooltip() {
+  tooltip.value.visible = false
+}
+
+onMounted(async () => {
+  if (props.preset === 'retail-access-story') {
+    metricMode.value = 'supermarkets_30min'
+  }
+
+  try {
+    const [boundaryRes, metricsRes, summaryRes] = await Promise.all([
+      fetch(boundaryUrl),
+      fetch(metricsUrl),
+      fetch(summaryUrl),
+    ])
+
+    if (!boundaryRes.ok || !metricsRes.ok || !summaryRes.ok) {
+      throw new Error('retail access missing')
+    }
+
+    const [boundaryJson, metricsJson, summaryJson] = await Promise.all([
+      boundaryRes.json(),
+      metricsRes.json(),
+      summaryRes.json(),
+    ])
+
+    boundary.value = boundaryJson
+    stations.value = metricsJson
+    summary.value = summaryJson
+
+    const defaultName = props.preset === 'retail-access-story' ? 'Lausanne' : 'Zürich HB'
+    selectedStationKey.value =
+      stations.value.find(station => station.station_name === defaultName)?.station_key ??
+      featuredStations.value[0]?.station_key ??
+      metricsJson[0]?.station_key ??
+      ''
+  } catch {
+    loadError.value = true
+  } finally {
+    loading.value = false
+  }
+})
+</script>
+
+<template>
+  <section class="retail-access section-frame">
+    <div class="retail-access__top">
+      <div class="retail-access__heading">
+        <span class="retail-access__kicker">Retail access</span>
+        <h3 class="retail-access__title">What the transport network buys in reachable retail</h3>
+        <p class="retail-access__text">
+          {{ metricConfig.label }} from a fixed <strong>08:00</strong> national export. The baseline is explicit so the map reads as a comparative product story, not as a live routing promise.
+        </p>
+      </div>
+
+      <div v-if="showControls" class="retail-access__metric-toggle" role="tablist" aria-label="Retail access metrics">
+        <button
+          class="retail-pill"
+          :class="{ 'is-active': metricMode === 'supermarkets_30min' }"
+          type="button"
+          @click="selectMetric('supermarkets_30min')"
+        >
+          Supermarkets
+        </button>
+        <button
+          class="retail-pill"
+          :class="{ 'is-active': metricMode === 'ikea_60min' }"
+          type="button"
+          @click="selectMetric('ikea_60min')"
+        >
+          IKEA
+        </button>
+      </div>
+    </div>
+
+    <div v-if="showControls" class="retail-access__station-pills" aria-label="Featured stations">
+      <button
+        v-for="station in featuredStations"
+        :key="station.station_key"
+        class="retail-pill"
+        :class="{ 'is-active': selectedStationKey === station.station_key }"
+        type="button"
+        @click="selectStation(station.station_key)"
+      >
+        {{ station.station_name }}
+      </button>
+    </div>
+
+    <div v-if="loadError" class="retail-access__fallback">
+      <p>The retail-access layer could not load. Other sections of the page still work.</p>
+    </div>
+
+    <div v-else class="retail-access__map-wrap">
+      <div v-if="loading" class="retail-access__loading">Loading retail access…</div>
+      <svg v-else class="retail-access__map" viewBox="0 0 1000 462" aria-label="Swiss retail access map">
+        <path :d="boundaryPath" class="retail-access__boundary" />
+        <circle
+          v-for="station in plottedStations"
+          :key="station.station_key"
+          :cx="station.cx"
+          :cy="station.cy"
+          :r="radiusFor(station.value, station.station_key)"
+          :fill="colorFor(station.value)"
+          class="retail-access__point"
+          :class="{ 'is-selected': station.station_key === selectedStationKey }"
+          @click="selectStation(station.station_key)"
+          @mouseenter="showTooltip($event, station)"
+          @mousemove="moveTooltip"
+          @mouseleave="hideTooltip"
+        />
+      </svg>
+    </div>
+
+    <div class="retail-access__footer">
+      <div class="retail-access__legend">
+        <span class="legend-text">{{ metricConfig.shortLabel }}</span>
+        <span class="legend-ramp" />
+        <span class="legend-text">Higher access</span>
+      </div>
+      <p class="retail-access__note">
+        {{ summary?.departure_time ?? '08:00' }} baseline · {{ selectedStation?.station_name ?? 'Station' }}: {{ selectedValue }} · top station: {{ topStationLabel }}
+      </p>
+    </div>
+  </section>
+
+  <div
+    v-if="tooltip.visible"
+    class="retail-tooltip"
+    :style="{ left: `${tooltip.x}px`, top: `${tooltip.y}px` }"
+  >
+    <strong>{{ tooltip.name }}</strong>
+    <span>{{ tooltip.value }}</span>
+  </div>
+</template>
+
+<style scoped>
+.retail-access {
+  display: grid;
+  grid-template-rows: auto auto minmax(0, 1fr) auto;
+  gap: 0.85rem;
+  padding: 0.85rem 0.85rem 0.78rem;
+  border-radius: var(--radius-shell);
+}
+
+.retail-access__top {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.retail-access__heading {
+  max-width: 38rem;
+}
+
+.retail-access__kicker {
+  color: var(--brand);
+  font-size: 0.72rem;
+  font-weight: 800;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+}
+
+.retail-access__title {
+  margin: 0.22rem 0 0;
+  color: var(--ink-strong);
+  font-size: 1.02rem;
+  letter-spacing: -0.03em;
+}
+
+.retail-access__text {
+  margin: 0.32rem 0 0;
+  color: var(--ink-soft);
+  font-size: 0.82rem;
+  line-height: 1.45;
+}
+
+.retail-access__metric-toggle,
+.retail-access__station-pills {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.retail-pill {
+  min-height: 2.2rem;
+  padding: 0 0.85rem;
+  border-radius: 999px;
+  border: 1px solid rgba(33, 28, 26, 0.08);
+  background: rgba(255, 255, 255, 0.82);
+  color: var(--ink-soft);
+  cursor: pointer;
+  transition:
+    border-color 180ms ease,
+    background-color 180ms ease,
+    color 180ms ease,
+    transform 180ms ease;
+}
+
+.retail-pill.is-active {
+  border-color: rgba(189, 45, 45, 0.18);
+  background: rgba(189, 45, 45, 0.12);
+  color: var(--brand);
+}
+
+.retail-pill:hover {
+  transform: translateY(-1px);
+}
+
+.retail-access__map-wrap {
+  min-height: 0;
+  position: relative;
+  border-radius: calc(var(--radius-shell) - 10px);
+  overflow: hidden;
+  border: 1px solid rgba(33, 28, 26, 0.07);
+  background:
+    radial-gradient(circle at top, rgba(255, 255, 255, 0.95), rgba(248, 244, 241, 0.96) 58%, rgba(241, 235, 230, 0.98));
+  height: 100%;
+}
+
+.retail-access__map {
+  width: 100%;
+  height: 100%;
+  display: block;
+}
+
+.retail-access__boundary {
+  fill: #efe9e2;
+  stroke: rgba(117, 103, 96, 0.65);
+  stroke-width: 1.1;
+}
+
+.retail-access__point {
+  cursor: pointer;
+  opacity: 0.9;
+  stroke: rgba(255, 255, 255, 0.55);
+  stroke-width: 0.6;
+  transition:
+    opacity 120ms ease,
+    stroke 120ms ease;
+}
+
+.retail-access__point.is-selected {
+  stroke: rgba(33, 28, 26, 0.7);
+  stroke-width: 1.2;
+}
+
+.retail-access__point:hover {
+  opacity: 1;
+}
+
+.retail-access__footer {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.8rem;
+}
+
+.retail-access__legend {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.55rem;
+}
+
+.legend-text {
+  color: var(--ink-soft);
+  font-size: 0.78rem;
+}
+
+.legend-ramp {
+  width: 7rem;
+  height: 0.5rem;
+  border-radius: 999px;
+  background: linear-gradient(90deg, #f4d7b4, #e99a54, #c95529, #9f1d1d);
+}
+
+.retail-access__note {
+  margin: 0;
+  color: var(--ink-soft);
+  font-size: 0.8rem;
+}
+
+.retail-access__loading,
+.retail-access__fallback {
+  display: grid;
+  place-items: center;
+  min-height: 12rem;
+  color: var(--ink-soft);
+  text-align: center;
+}
+
+.retail-tooltip {
+  position: fixed;
+  z-index: 30;
+  display: grid;
+  gap: 0.16rem;
+  min-width: 10rem;
+  padding: 0.72rem 0.82rem;
+  border-radius: 16px;
+  background: rgba(33, 28, 26, 0.92);
+  color: #fff;
+  pointer-events: none;
+  box-shadow: 0 12px 32px rgba(33, 28, 26, 0.22);
+}
+
+.retail-tooltip strong {
+  font-size: 0.86rem;
+}
+
+.retail-tooltip span {
+  font-size: 0.76rem;
+  color: rgba(255, 255, 255, 0.78);
+}
+
+@media (max-width: 960px) {
+  .retail-access__top {
+    display: grid;
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 720px) {
+  .retail-access {
+    padding: 0.72rem;
+  }
+
+  .retail-access__title {
+    font-size: 0.96rem;
+  }
+}
+</style>

--- a/frontend/src/components/RetailDensityMap.vue
+++ b/frontend/src/components/RetailDensityMap.vue
@@ -1,0 +1,596 @@
+<script setup lang="ts">
+import { computed, onMounted, ref } from 'vue'
+import * as d3 from 'd3'
+
+import type { StoryMediaPreset } from '@/content/productStory'
+import { withBase } from '@/utils/assets'
+
+type BrandMode = 'both' | 'migros' | 'coop' | 'difference'
+
+interface StorePoint {
+  brand: 'Migros' | 'Coop'
+  name: string
+  lat: number
+  lon: number
+  city: string | null
+  postcode: string | null
+  source_url: string
+}
+
+interface HexBin {
+  key: string
+  q: number
+  r: number
+  cx: number
+  cy: number
+  total: number
+  migros: number
+  coop: number
+}
+
+const props = defineProps<{
+  preset: StoryMediaPreset
+}>()
+
+const HEX_SIZE = 11.5
+const SQRT_3 = Math.sqrt(3)
+const HEX_ORIGIN_X = 118
+const HEX_ORIGIN_Y = 62
+
+const boundary = ref<object | null>(null)
+const migrosStores = ref<StorePoint[]>([])
+const coopStores = ref<StorePoint[]>([])
+const loading = ref(true)
+const loadError = ref(false)
+const tooltip = ref({
+  visible: false,
+  x: 0,
+  y: 0,
+  title: '',
+  lines: [] as string[],
+})
+
+const boundaryUrl = withBase('/data/swiss_boundary_wgs84.geojson')
+const migrosUrl = withBase('/data/migros_stores_min.json')
+const coopUrl = withBase('/data/coop_stores_min.json')
+
+const presetMode = computed<BrandMode>(() => {
+  if (props.preset === 'brand-story' || props.preset === 'brand-playground') {
+    return 'difference'
+  }
+  return 'both'
+})
+
+const showControls = computed(() => props.preset === 'retail-playground' || props.preset === 'brand-playground')
+const brandMode = ref<BrandMode>(presetMode.value)
+
+const allStores = computed(() => [...migrosStores.value, ...coopStores.value])
+
+const projection = computed(() => {
+  if (!boundary.value) {
+    return null
+  }
+  return d3.geoMercator().fitExtent(
+    [[22, 18], [978, 446]],
+    boundary.value as any,
+  )
+})
+
+const boundaryPath = computed(() => {
+  if (!projection.value || !boundary.value) {
+    return ''
+  }
+  return d3.geoPath(projection.value)(boundary.value as any) ?? ''
+})
+
+const plottedStores = computed(() => {
+  if (!projection.value) {
+    return []
+  }
+
+  return allStores.value
+    .map(store => {
+      const projected = projection.value?.([store.lon, store.lat])
+      if (!projected) {
+        return null
+      }
+      return {
+        ...store,
+        cx: projected[0],
+        cy: projected[1],
+      }
+    })
+    .filter((item): item is StorePoint & { cx: number; cy: number } => item !== null)
+})
+
+const displayedCount = computed(() => {
+  if (brandMode.value === 'migros') {
+    return migrosStores.value.length
+  }
+  if (brandMode.value === 'coop') {
+    return coopStores.value.length
+  }
+  return allStores.value.length
+})
+
+const totalCount = computed(() => allStores.value.length)
+const migrosShare = computed(() => {
+  if (!totalCount.value) {
+    return '0%'
+  }
+  return `${Math.round((migrosStores.value.length / totalCount.value) * 100)}%`
+})
+const coopShare = computed(() => {
+  if (!totalCount.value) {
+    return '0%'
+  }
+  return `${Math.round((coopStores.value.length / totalCount.value) * 100)}%`
+})
+
+const mapTitle = computed(() => {
+  if (props.preset === 'brand-story' || props.preset === 'brand-playground') {
+    return 'Brand contrast'
+  }
+  return 'Retail footprint'
+})
+
+const mapNote = computed(() => {
+  if (brandMode.value === 'difference') {
+    return 'Hex cells show where one supermarket network outweighs the other, instead of forcing both brands into the same point cloud.'
+  }
+  if (brandMode.value === 'both') {
+    return 'Hex cells summarize the shared Swiss supermarket footprint so clusters read at a glance.'
+  }
+  return `Hex cells isolate the ${brandMode.value === 'migros' ? 'Migros' : 'Coop'} network without losing the national pattern.`
+})
+
+function pixelToAxial(x: number, y: number) {
+  const localX = x - HEX_ORIGIN_X
+  const localY = y - HEX_ORIGIN_Y
+  const q = ((SQRT_3 / 3) * localX - localY / 3) / HEX_SIZE
+  const r = ((2 / 3) * localY) / HEX_SIZE
+  return { q, r }
+}
+
+function axialRound(q: number, r: number) {
+  const x = q
+  const z = r
+  const y = -x - z
+
+  let rx = Math.round(x)
+  let ry = Math.round(y)
+  let rz = Math.round(z)
+
+  const xDiff = Math.abs(rx - x)
+  const yDiff = Math.abs(ry - y)
+  const zDiff = Math.abs(rz - z)
+
+  if (xDiff > yDiff && xDiff > zDiff) {
+    rx = -ry - rz
+  } else if (yDiff > zDiff) {
+    ry = -rx - rz
+  } else {
+    rz = -rx - ry
+  }
+
+  return { q: rx, r: rz }
+}
+
+function axialToPixel(q: number, r: number) {
+  const x = HEX_SIZE * SQRT_3 * (q + r / 2) + HEX_ORIGIN_X
+  const y = HEX_SIZE * 1.5 * r + HEX_ORIGIN_Y
+  return { x, y }
+}
+
+function hexPath(cx: number, cy: number) {
+  const points = Array.from({ length: 6 }, (_, index) => {
+    const angle = ((60 * index - 30) * Math.PI) / 180
+    const x = cx + HEX_SIZE * Math.cos(angle)
+    const y = cy + HEX_SIZE * Math.sin(angle)
+    return `${x},${y}`
+  })
+  return `M${points.join(' L')} Z`
+}
+
+const hexBins = computed<HexBin[]>(() => {
+  const bins = new Map<string, HexBin>()
+
+  for (const store of plottedStores.value) {
+    const axial = pixelToAxial(store.cx, store.cy)
+    const rounded = axialRound(axial.q, axial.r)
+    const key = `${rounded.q},${rounded.r}`
+    const existing = bins.get(key)
+
+    if (existing) {
+      existing.total += 1
+      if (store.brand === 'Migros') {
+        existing.migros += 1
+      } else {
+        existing.coop += 1
+      }
+      continue
+    }
+
+    const center = axialToPixel(rounded.q, rounded.r)
+    bins.set(key, {
+      key,
+      q: rounded.q,
+      r: rounded.r,
+      cx: center.x,
+      cy: center.y,
+      total: 1,
+      migros: store.brand === 'Migros' ? 1 : 0,
+      coop: store.brand === 'Coop' ? 1 : 0,
+    })
+  }
+
+  return [...bins.values()]
+})
+
+const maxBinTotal = computed(() => d3.max(hexBins.value, bin => bin.total) ?? 1)
+const maxBinDiff = computed(() => d3.max(hexBins.value, bin => Math.abs(bin.migros - bin.coop)) ?? 1)
+
+function fillFor(bin: HexBin): string {
+  if (brandMode.value === 'difference') {
+    const diff = bin.migros - bin.coop
+    if (diff === 0) {
+      return 'rgba(161, 145, 128, 0.52)'
+    }
+    const strength = Math.abs(diff) / Math.max(maxBinDiff.value, 1)
+    return diff > 0
+      ? d3.interpolateRgb('rgba(246,226,220,0.76)', 'rgba(189,45,45,0.92)')(0.28 + strength * 0.72)
+      : d3.interpolateRgb('rgba(241,232,210,0.78)', 'rgba(180,126,26,0.96)')(0.28 + strength * 0.72)
+  }
+
+  const intensity = bin.total / Math.max(maxBinTotal.value, 1)
+  if (brandMode.value === 'migros') {
+    return d3.interpolateRgb('rgba(248,228,223,0.74)', 'rgba(189,45,45,0.94)')(0.22 + intensity * 0.78)
+  }
+  if (brandMode.value === 'coop') {
+    return d3.interpolateRgb('rgba(243,235,214,0.76)', 'rgba(180,126,26,0.96)')(0.22 + intensity * 0.78)
+  }
+  return d3.interpolateRgb('rgba(247,238,226,0.72)', 'rgba(145,97,33,0.96)')(0.2 + intensity * 0.8)
+}
+
+function strokeFor(bin: HexBin): string {
+  if (brandMode.value === 'difference') {
+    if (bin.migros === bin.coop) {
+      return 'rgba(122, 111, 100, 0.3)'
+    }
+    return bin.migros > bin.coop ? 'rgba(151, 31, 31, 0.62)' : 'rgba(142, 96, 18, 0.62)'
+  }
+  return 'rgba(88, 73, 62, 0.22)'
+}
+
+function showTooltip(event: MouseEvent, bin: HexBin) {
+  const lines =
+    brandMode.value === 'difference'
+      ? [`Migros ${bin.migros}`, `Coop ${bin.coop}`, `Difference ${Math.abs(bin.migros - bin.coop)}`]
+      : [`Total ${bin.total}`, `Migros ${bin.migros}`, `Coop ${bin.coop}`]
+
+  tooltip.value = {
+    visible: true,
+    x: event.clientX + 14,
+    y: event.clientY - 16,
+    title: brandMode.value === 'difference' ? 'Brand balance' : 'Store density',
+    lines,
+  }
+}
+
+function moveTooltip(event: MouseEvent) {
+  tooltip.value.x = event.clientX + 14
+  tooltip.value.y = event.clientY - 16
+}
+
+function hideTooltip() {
+  tooltip.value.visible = false
+}
+
+function setBrandMode(nextMode: BrandMode) {
+  brandMode.value = nextMode
+}
+
+onMounted(async () => {
+  brandMode.value = presetMode.value
+
+  try {
+    const [boundaryRes, migrosRes, coopRes] = await Promise.all([
+      fetch(boundaryUrl),
+      fetch(migrosUrl),
+      fetch(coopUrl),
+    ])
+
+    if (!boundaryRes.ok || !migrosRes.ok || !coopRes.ok) {
+      throw new Error('retail data missing')
+    }
+
+    const [boundaryJson, migrosJson, coopJson] = await Promise.all([
+      boundaryRes.json(),
+      migrosRes.json(),
+      coopRes.json(),
+    ])
+
+    boundary.value = boundaryJson
+    migrosStores.value = migrosJson
+    coopStores.value = coopJson
+  } catch {
+    loadError.value = true
+  } finally {
+    loading.value = false
+  }
+})
+</script>
+
+<template>
+  <section class="retail-density section-frame">
+    <div class="retail-density__top">
+      <div class="retail-density__heading">
+        <span class="retail-density__kicker">{{ mapTitle }}</span>
+        <h3 class="retail-density__title">Retail density in Switzerland</h3>
+        <p class="retail-density__text">{{ mapNote }}</p>
+      </div>
+
+      <div v-if="showControls" class="retail-density__controls" role="tablist" aria-label="Brand filters">
+        <button class="retail-pill" :class="{ 'is-active': brandMode === 'both' }" type="button" @click="setBrandMode('both')">
+          Both
+        </button>
+        <button class="retail-pill" :class="{ 'is-active': brandMode === 'migros' }" type="button" @click="setBrandMode('migros')">
+          Migros
+        </button>
+        <button class="retail-pill" :class="{ 'is-active': brandMode === 'coop' }" type="button" @click="setBrandMode('coop')">
+          Coop
+        </button>
+        <button
+          v-if="preset === 'brand-playground'"
+          class="retail-pill"
+          :class="{ 'is-active': brandMode === 'difference' }"
+          type="button"
+          @click="setBrandMode('difference')"
+        >
+          Difference
+        </button>
+      </div>
+    </div>
+
+    <div v-if="loadError" class="retail-density__fallback">
+      <p>The retail footprint could not load. The rest of the story remains available.</p>
+    </div>
+
+    <div v-else class="retail-density__map-wrap">
+      <div v-if="loading" class="retail-density__loading">Loading retail footprint…</div>
+      <svg v-else class="retail-density__map" viewBox="0 0 1000 464" aria-label="Swiss retail density hex map">
+        <path :d="boundaryPath" class="retail-density__boundary" />
+        <path
+          v-for="bin in hexBins"
+          :key="bin.key"
+          :d="hexPath(bin.cx, bin.cy)"
+          :fill="fillFor(bin)"
+          :stroke="strokeFor(bin)"
+          class="retail-density__hex"
+          @mouseenter="showTooltip($event, bin)"
+          @mousemove="moveTooltip"
+          @mouseleave="hideTooltip"
+        />
+      </svg>
+    </div>
+
+    <div class="retail-density__legend">
+      <span class="legend-chip"><i class="legend-dot legend-dot--migros" /> Migros</span>
+      <span class="legend-chip"><i class="legend-dot legend-dot--coop" /> Coop</span>
+      <span v-if="brandMode === 'difference'" class="legend-chip"><i class="legend-dot legend-dot--neutral" /> Balanced</span>
+      <span class="legend-text">{{ displayedCount }} stores · {{ hexBins.length }} hex cells · Migros {{ migrosShare }} · Coop {{ coopShare }}</span>
+    </div>
+  </section>
+
+  <div
+    v-if="tooltip.visible"
+    class="retail-tooltip"
+    :style="{ left: `${tooltip.x}px`, top: `${tooltip.y}px` }"
+  >
+    <strong>{{ tooltip.title }}</strong>
+    <span v-for="line in tooltip.lines" :key="line">{{ line }}</span>
+  </div>
+</template>
+
+<style scoped>
+.retail-density {
+  display: grid;
+  grid-template-rows: auto minmax(0, 1fr) auto;
+  gap: 0.9rem;
+  padding: 0.85rem 0.85rem 0.75rem;
+  border-radius: var(--radius-shell);
+}
+
+.retail-density__top {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.retail-density__heading {
+  max-width: 34rem;
+}
+
+.retail-density__kicker {
+  color: var(--brand);
+  font-size: 0.72rem;
+  font-weight: 800;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+}
+
+.retail-density__title {
+  margin: 0.22rem 0 0;
+  color: var(--ink-strong);
+  font-size: 1.02rem;
+  letter-spacing: -0.03em;
+}
+
+.retail-density__text {
+  margin: 0.32rem 0 0;
+  color: var(--ink-soft);
+  font-size: 0.82rem;
+  line-height: 1.45;
+}
+
+.retail-density__controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  justify-content: flex-end;
+}
+
+.retail-pill {
+  min-height: 2.2rem;
+  padding: 0 0.85rem;
+  border-radius: 999px;
+  border: 1px solid rgba(33, 28, 26, 0.08);
+  background: rgba(255, 255, 255, 0.82);
+  color: var(--ink-soft);
+  cursor: pointer;
+  transition:
+    border-color 180ms ease,
+    background-color 180ms ease,
+    color 180ms ease,
+    transform 180ms ease;
+}
+
+.retail-pill.is-active {
+  border-color: rgba(189, 45, 45, 0.18);
+  background: rgba(189, 45, 45, 0.12);
+  color: var(--brand);
+}
+
+.retail-pill:hover {
+  transform: translateY(-1px);
+}
+
+.retail-density__map-wrap {
+  min-height: 0;
+  position: relative;
+  border-radius: calc(var(--radius-shell) - 10px);
+  overflow: hidden;
+  border: 1px solid rgba(33, 28, 26, 0.07);
+  background:
+    radial-gradient(circle at top, rgba(255, 255, 255, 0.95), rgba(248, 244, 241, 0.96) 58%, rgba(241, 235, 230, 0.98));
+  height: 100%;
+}
+
+.retail-density__map {
+  width: 100%;
+  height: 100%;
+  display: block;
+}
+
+.retail-density__boundary {
+  fill: #f4efe9;
+  stroke: rgba(117, 103, 96, 0.6);
+  stroke-width: 1.15;
+}
+
+.retail-density__hex {
+  transition:
+    transform 120ms ease,
+    opacity 120ms ease,
+    stroke 120ms ease;
+  opacity: 0.96;
+  stroke-width: 0.8;
+}
+
+.retail-density__hex:hover {
+  opacity: 1;
+  stroke: rgba(33, 28, 26, 0.66);
+}
+
+.retail-density__legend {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.8rem;
+}
+
+.legend-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.42rem;
+  color: var(--ink);
+  font-size: 0.8rem;
+}
+
+.legend-dot {
+  width: 0.65rem;
+  height: 0.65rem;
+  border-radius: 999px;
+}
+
+.legend-dot--migros {
+  background: rgba(189, 45, 45, 0.92);
+}
+
+.legend-dot--coop {
+  background: rgba(180, 126, 26, 0.92);
+}
+
+.legend-dot--neutral {
+  background: rgba(161, 145, 128, 0.9);
+}
+
+.legend-text {
+  color: var(--ink-soft);
+  font-size: 0.78rem;
+}
+
+.retail-density__loading,
+.retail-density__fallback {
+  display: grid;
+  place-items: center;
+  min-height: 12rem;
+  color: var(--ink-soft);
+  text-align: center;
+}
+
+.retail-tooltip {
+  position: fixed;
+  z-index: 30;
+  display: grid;
+  gap: 0.16rem;
+  min-width: 10rem;
+  padding: 0.72rem 0.82rem;
+  border-radius: 16px;
+  background: rgba(33, 28, 26, 0.92);
+  color: #fff;
+  pointer-events: none;
+  box-shadow: 0 12px 32px rgba(33, 28, 26, 0.22);
+}
+
+.retail-tooltip strong {
+  font-size: 0.86rem;
+}
+
+.retail-tooltip span {
+  font-size: 0.76rem;
+  color: rgba(255, 255, 255, 0.78);
+}
+
+@media (max-width: 960px) {
+  .retail-density__top {
+    display: grid;
+    grid-template-columns: 1fr;
+  }
+
+  .retail-density__controls {
+    justify-content: flex-start;
+  }
+}
+
+@media (max-width: 720px) {
+  .retail-density {
+    padding: 0.72rem;
+  }
+
+  .retail-density__title {
+    font-size: 0.96rem;
+  }
+}
+</style>

--- a/frontend/src/components/product/CoreStorySection.vue
+++ b/frontend/src/components/product/CoreStorySection.vue
@@ -117,8 +117,12 @@ const transitionName = computed(() => (direction.value > 0 ? 'story-forward' : '
 }
 
 @media (max-width: 720px) {
-  .story-shell,
+  .story-shell {
+    height: calc(var(--panel-count) * 100dvh);
+  }
+
   .story-stage {
+    height: 100dvh;
     min-height: 100dvh;
   }
 }

--- a/frontend/src/components/product/HeroSection.vue
+++ b/frontend/src/components/product/HeroSection.vue
@@ -12,6 +12,10 @@ import { heroPreviewUrl } from '@/content/productStory'
           everyday reachability, visualized Switzerland
         </h1>
 
+        <p class="hero-summary">
+          Start with the rail backbone, then read what it means for daily supermarket access, regional retail density, and brand structure across Switzerland.
+        </p>
+
         <div class="button-row hero-actions">
           <a class="button-primary" href="#story">Explore the map</a>
           <a class="button-secondary" href="https://swissreach.online/docs/">Read the docs</a>
@@ -58,9 +62,11 @@ import { heroPreviewUrl } from '@/content/productStory'
 
 <style scoped>
 .hero-shell {
+  height: 100svh;
   min-height: 100svh;
-  padding-top: clamp(3.5rem, 8vw, 7rem);
-  padding-bottom: clamp(4rem, 8vw, 7rem);
+  box-sizing: border-box;
+  padding-top: var(--section-top-padding);
+  padding-bottom: var(--section-bottom-padding);
   display: grid;
   align-items: center;
 }
@@ -88,6 +94,14 @@ import { heroPreviewUrl } from '@/content/productStory'
 
 .hero-actions {
   margin-top: 1.9rem;
+}
+
+.hero-summary {
+  margin: 1.2rem 0 0;
+  max-width: 38rem;
+  color: var(--ink-soft);
+  font-size: 1.03rem;
+  line-height: 1.7;
 }
 
 .text-brand {
@@ -187,6 +201,7 @@ import { heroPreviewUrl } from '@/content/productStory'
 
 @media (max-width: 720px) {
   .hero-shell {
+    height: 100dvh;
     min-height: 100dvh;
     align-items: start;
   }

--- a/frontend/src/components/product/HeroSection.vue
+++ b/frontend/src/components/product/HeroSection.vue
@@ -13,17 +13,17 @@ import { heroPreviewUrl } from '@/content/productStory'
         </h1>
 
         <p class="hero-summary">
-          Start with the rail backbone, then read what it means for daily supermarket access, regional retail density, and brand structure across Switzerland.
+          Swiss public transport, retail density, and everyday access in one national view.
         </p>
 
         <div class="button-row hero-actions">
-          <a class="button-primary" href="#story">Explore the map</a>
-          <a class="button-secondary" href="https://swissreach.online/docs/">Read the docs</a>
+          <a class="button-primary" href="#story">Enter</a>
+          <a class="button-secondary" href="https://swissreach.online/docs/">Docs</a>
         </div>
 
         <div class="hero-guidance">
           <span class="hero-guidance__line" />
-          <span class="hero-guidance__text">Scroll to move through the story</span>
+          <span class="hero-guidance__text">Scroll to continue</span>
         </div>
       </div>
 

--- a/frontend/src/components/product/IntroSection.vue
+++ b/frontend/src/components/product/IntroSection.vue
@@ -7,10 +7,10 @@ import { introMetrics } from '@/content/productStory'
     <div class="intro-copy">
       <p class="section-label">Overview</p>
       <h2 class="section-title">
-        Understanding practical reach, not just abstract network scale.
+        Strong transport coverage does not automatically turn into strong daily retail opportunity.
       </h2>
       <p class="section-text">
-        SwissReach illustrates where the railway network carries weight, where coverage begins to thin out, and why that difference matters once daily routines—like accessing schools or hospitals—enter the picture. We connect transit schedules with everyday points of interest.
+        SwissReach starts with the national rail backbone, then asks the more practical question hiding underneath it: once the network is there, what kind of everyday choice does it actually unlock? That is why the page moves from reachability, to store geography, to retail access, instead of treating supermarkets as a small add-on at the end.
       </p>
     </div>
 
@@ -27,9 +27,11 @@ import { introMetrics } from '@/content/productStory'
 
 <style scoped>
 .intro-shell {
+  height: 100svh;
   min-height: 100svh;
-  padding-top: clamp(5rem, 8vw, 7rem);
-  padding-bottom: clamp(4.5rem, 7vw, 6.5rem);
+  box-sizing: border-box;
+  padding-top: var(--section-top-padding);
+  padding-bottom: var(--section-bottom-padding);
   display: grid;
   align-content: center;
   gap: 2.25rem;
@@ -53,10 +55,9 @@ import { introMetrics } from '@/content/productStory'
 
 @media (max-width: 720px) {
   .intro-shell {
+    height: 100dvh;
     min-height: 100dvh;
     align-content: start;
-    padding-top: 6.5rem;
-    padding-bottom: 3rem;
   }
 }
 </style>

--- a/frontend/src/components/product/OutroSection.vue
+++ b/frontend/src/components/product/OutroSection.vue
@@ -2,12 +2,12 @@
   <section id="outro" class="page-section outro-shell">
     <div class="outro-grid">
       <div class="outro-copy">
-        <p class="section-label">Methodology</p>
+        <p class="section-label">Closing</p>
         <h2 class="section-title">
-          Built on open data from Swiss GTFS and structured POI datasets.
+          Mobility explains connection. Retail explains opportunity. SwissReach is useful because it keeps both in the same frame.
         </h2>
         <p class="section-text">
-          By processing national timetables and combining them with geospatial amenity data, SwissReach provides a trustworthy sense of what daily movement really looks like and how infrastructure caters to public needs.
+          The transport network tells us where Switzerland is well linked; the retail layer tells us what that linkage means for everyday life. Reading those layers together makes it easier to spot where a strong backbone really expands choice and where it still leaves daily opportunity uneven.
         </p>
 
         <div class="button-row outro-actions">
@@ -18,15 +18,15 @@
 
       <div class="outro-cards">
         <article class="outro-card section-frame">
-          <span class="outro-card__label">Data Layer</span>
-          <strong>Retail competition stories</strong>
-          <p>A dedicated supermarket dataset supports Migros vs Coop density analysis and broader food-retail mapping.</p>
+          <span class="outro-card__label">Argument</span>
+          <strong>Transport alone is not the whole story</strong>
+          <p>The page deliberately moves from rail geometry to reachable supermarkets so “coverage” never stays abstract for long.</p>
         </article>
         <article class="outro-card section-frame">
-          <span class="outro-card__label">Data Layer</span>
-          <strong>Consistent POI mappings</strong>
+          <span class="outro-card__label">Method</span>
+          <strong>Open GTFS and POI layers stay visible</strong>
           <p>
-            30-minute access counts for supermarkets, schools, and hospitals, alongside a 60-minute IKEA access coverage.
+            The current demo combines national timetable structure, station-level POI counts, and a branded supermarket export without pretending to be a live router.
           </p>
         </article>
       </div>
@@ -36,9 +36,11 @@
 
 <style scoped>
 .outro-shell {
+  height: 100svh;
   min-height: 100svh;
-  padding-top: clamp(5rem, 8vw, 7rem);
-  padding-bottom: clamp(5rem, 8vw, 7rem);
+  box-sizing: border-box;
+  padding-top: var(--section-top-padding);
+  padding-bottom: var(--section-bottom-padding);
   display: grid;
   align-items: center;
 }
@@ -97,10 +99,9 @@
 
 @media (max-width: 720px) {
   .outro-shell {
+    height: 100dvh;
     min-height: 100dvh;
     align-items: start;
-    padding-top: 6.5rem;
-    padding-bottom: 3rem;
   }
 }
 </style>

--- a/frontend/src/components/product/ProductTopbar.vue
+++ b/frontend/src/components/product/ProductTopbar.vue
@@ -13,8 +13,8 @@ import { brandLogoUrl } from '@/content/productStory'
       <nav class="nav-links" aria-label="Primary">
         <a href="#hero">Home</a>
         <a href="#intro">Overview</a>
-        <a href="#story">Map Layers</a>
-        <a href="#outro">Methodology</a>
+        <a href="#story">Experience</a>
+        <a href="#outro">Closing</a>
       </nav>
     </div>
   </header>

--- a/frontend/src/components/product/StoryMedia.vue
+++ b/frontend/src/components/product/StoryMedia.vue
@@ -3,6 +3,8 @@ import { type StoryPanelContent } from '@/content/productStory'
 import ReachabilityMap from '@/components/ReachabilityMap.vue'
 import LausanneReachabilityLab from '@/components/LausanneReachabilityLab.vue'
 import BusiestRailChart from '@/components/BusiestRailChart.vue'
+import RetailDensityMap from '@/components/RetailDensityMap.vue'
+import RetailAccessMap from '@/components/RetailAccessMap.vue'
 
 defineProps<{
   panel: StoryPanelContent
@@ -11,10 +13,20 @@ defineProps<{
 
 <template>
   <!-- @wheel.stop prevents GSAP from turning slides when scrolling inside the map -->
-  <figure class="media-shell section-frame" :data-variant="panel.mediaVariant" @wheel.stop>
+  <figure class="media-shell" :data-variant="panel.mediaVariant" @wheel.stop>
     <ReachabilityMap v-if="panel.mediaVariant === 'reachability-map'" class="interactive-embed" />
     <LausanneReachabilityLab v-else-if="panel.mediaVariant === 'reachability-lab'" class="interactive-embed" />
     <BusiestRailChart v-else-if="panel.mediaVariant === 'busiest-rail'" class="interactive-embed" />
+    <RetailDensityMap
+      v-else-if="panel.mediaVariant === 'retail-density'"
+      class="interactive-embed"
+      :preset="panel.mediaPreset"
+    />
+    <RetailAccessMap
+      v-else-if="panel.mediaVariant === 'retail-access'"
+      class="interactive-embed"
+      :preset="panel.mediaPreset"
+    />
   </figure>
 </template>
 
@@ -25,7 +37,6 @@ defineProps<{
   width: 100%;
   height: 100%; 
   min-height: 0;
-  border-radius: var(--radius-shell);
   overflow: hidden;
   padding: 0;
   display: flex;
@@ -34,18 +45,14 @@ defineProps<{
 .interactive-embed {
   width: 100%;
   height: 100%;
-  border-radius: var(--radius-shell);
-  background: white;
 }
 
 :deep(.map-wrapper),
 :deep(.lab),
-:deep(.chart-shell) {
-  padding: 1rem;
+:deep(.retail-density),
+:deep(.retail-access) {
   width: 100%;
   height: 100%;
   box-sizing: border-box;
 }
-
-
 </style>

--- a/frontend/src/components/product/StoryPanel.vue
+++ b/frontend/src/components/product/StoryPanel.vue
@@ -19,7 +19,10 @@ defineProps<{
     <div class="story-panel__inner">
       <div class="story-panel__copy">
         <div class="story-panel__copy-main">
-          <p class="story-panel__eyebrow">{{ panel.eyebrow }}</p>
+          <div class="story-panel__meta">
+            <span class="story-panel__topic">{{ panel.topic }}</span>
+            <span class="story-panel__kind">{{ panel.panelKind }}</span>
+          </div>
           <h3 class="story-panel__title">{{ panel.title }}</h3>
         </div>
         <div class="story-panel__copy-side">
@@ -29,7 +32,9 @@ defineProps<{
 
       <div class="story-panel__media-wrap">
         <StoryMedia :panel="panel" />
-        <p class="story-panel__caption">{{ panel.mediaCaption }}</p>
+        <div class="story-panel__footer">
+          <p class="story-panel__caption">{{ panel.mediaCaption }}</p>
+        </div>
       </div>
     </div>
   </article>
@@ -38,42 +43,75 @@ defineProps<{
 <style scoped>
 .story-panel {
   height: 100svh;
+  box-sizing: border-box;
   display: flex;
   align-items: center;
   padding:
-    clamp(6.5rem, 10vw, 7.75rem)
+    var(--section-top-padding)
     0
-    clamp(4.5rem, 8vw, 6rem);
+    var(--section-bottom-padding);
 }
 
 .story-panel__inner {
   width: 100%;
   height: 100%;
-  max-height: calc(100svh - 8rem);
+  max-height: calc(100svh - var(--section-top-padding) - var(--section-bottom-padding));
   display: flex;
   flex-direction: column;
-  gap: clamp(1.2rem, 2.5vw, 2.2rem);
-  padding: clamp(0.6rem, 1.4vw, 1rem);
+  gap: clamp(0.7rem, 1.5vw, 1rem);
+  padding: clamp(0.25rem, 1vw, 0.5rem);
 }
 
 .story-panel__copy {
   display: grid;
-  grid-template-columns: 1fr 1.5fr;
-  gap: clamp(2rem, 5vw, 5rem);
-  align-items: center;
+  grid-template-columns: minmax(0, 1.2fr) minmax(0, 1fr);
+  gap: clamp(1rem, 2vw, 1.6rem);
+  align-items: end;
   width: 100%;
 }
 
 .story-panel__copy-main {
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: 0.35rem;
+  min-width: 0;
+}
+
+.story-panel__meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.45rem;
+}
+
+.story-panel__topic,
+.story-panel__kind {
+  display: inline-flex;
+  align-items: center;
+  min-height: 1.7rem;
+  padding: 0 0.62rem;
+  border-radius: 999px;
+  font-size: 0.68rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.story-panel__topic {
+  background: rgba(189, 45, 45, 0.12);
+  color: var(--brand);
+}
+
+.story-panel__kind {
+  background: rgba(255, 255, 255, 0.92);
+  border: 1px solid var(--line);
+  color: var(--ink-soft);
 }
 
 .story-panel__copy-side {
   display: flex;
   flex-direction: column;
   justify-content: center;
+  min-width: 0;
 }
 
 .story-panel__count {
@@ -91,31 +129,23 @@ defineProps<{
   text-transform: uppercase;
 }
 
-.story-panel__eyebrow {
-  margin: 0;
-  color: var(--brand);
-  font-size: 0.8rem;
-  font-weight: 700;
-  letter-spacing: 0.18em;
-  text-transform: uppercase;
-}
-
 .story-panel__title {
   margin: 0;
-  max-width: 25ch;
+  max-width: 22ch;
   color: var(--ink-strong);
-  font-size: clamp(2rem, 3vw, 3.2rem);
+  font-size: clamp(1.45rem, 2vw, 2.05rem);
   line-height: 1.02;
   letter-spacing: -0.045em;
   font-weight: 700;
+  text-wrap: balance;
 }
 
 .story-panel__description {
   margin: 0;
-  max-width: 55rem;
+  max-width: 48rem;
   color: var(--ink-soft);
-  font-size: 1.1rem;
-  line-height: 1.5;
+  font-size: 0.94rem;
+  line-height: 1.54;
   padding-bottom: 0;
 }
 
@@ -124,15 +154,22 @@ defineProps<{
   flex-direction: column;
   flex: 1;
   min-height: 0;
-  gap: 0.8rem;
+  gap: 0.7rem;
   align-self: stretch;
+}
+
+.story-panel__footer {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  align-items: flex-start;
 }
 
 .story-panel__caption {
   margin: 0;
-  max-width: 42rem;
+  max-width: 48rem;
   color: var(--ink-soft);
-  font-size: 0.84rem;
+  font-size: 0.78rem;
   line-height: 1.48;
 }
 
@@ -144,10 +181,14 @@ defineProps<{
 
 @media (max-width: 1024px) {
   .story-panel__inner {
-    max-height: calc(100svh - 11rem);
+    max-height: calc(100svh - var(--section-top-padding) - var(--section-bottom-padding));
     padding-right: 0.25rem;
   }
 
+  .story-panel__copy {
+    grid-template-columns: 1fr;
+    gap: 0.7rem;
+  }
 
   .story-panel__title {
     max-width: none;
@@ -157,7 +198,7 @@ defineProps<{
 @media (max-width: 720px) {
   .story-panel {
     height: 100dvh;
-    padding: 5.7rem 0 4.5rem;
+    padding: var(--section-top-padding) 0 var(--section-bottom-padding);
   }
 
   .story-panel__description {
@@ -165,9 +206,12 @@ defineProps<{
   }
 
   .story-panel__inner {
-    max-height: calc(100dvh - 10.2rem);
-    padding: 0.4rem;
-    border-radius: 24px;
+    max-height: calc(100dvh - var(--section-top-padding) - var(--section-bottom-padding));
+    padding: 0.2rem;
+  }
+
+  .story-panel__caption {
+    font-size: 0.8rem;
   }
 }
 </style>

--- a/frontend/src/content/productStory.ts
+++ b/frontend/src/content/productStory.ts
@@ -8,10 +8,27 @@ export interface MetricItem {
   tone?: MetricTone
 }
 
-export type StoryMediaVariant = 'reachability-map' | 'reachability-lab' | 'busiest-rail'
+export type StoryMediaVariant =
+  | 'reachability-map'
+  | 'reachability-lab'
+  | 'busiest-rail'
+  | 'retail-density'
+  | 'retail-access'
+export type StoryMediaPreset =
+  | 'transport-story'
+  | 'transport-playground'
+  | 'transport-load'
+  | 'retail-story'
+  | 'retail-playground'
+  | 'retail-access-story'
+  | 'retail-access-playground'
+  | 'brand-story'
+  | 'brand-playground'
 
 export interface StoryPanelContent {
   id: string
+  topic: string
+  panelKind: 'Story' | 'Playground'
   navLabel: string
   eyebrow: string
   title: string
@@ -19,6 +36,7 @@ export interface StoryPanelContent {
   highlights: string[]
   metrics: MetricItem[]
   mediaVariant: StoryMediaVariant
+  mediaPreset: StoryMediaPreset
   mediaCaption: string
 }
 
@@ -27,84 +45,323 @@ export const brandLogoUrl = withBase('/logo/SwissReach_vectorized.png')
 
 export const introMetrics: MetricItem[] = [
   {
-    value: '4 anchor cities',
-    label: 'A consistent view across Lausanne, Bern, Geneva and Zurich.',
+    value: '08:00 baseline',
+    label: 'The retail-access layer stays explicit about the fixed morning departure it uses.',
     tone: 'brand',
   },
   {
-    value: '1,938 stations',
-    label: 'Swiss GTFS is collapsed from raw stops into logical rail stations.',
+    value: '1,663 stations',
+    label: 'National comparisons are anchored on logical Swiss rail stations with exported POI counts.',
     tone: 'neutral',
   },
   {
-    value: 'Daily essentials',
-    label: 'Coverage is framed around supermarkets, schools, hospitals, and more.',
+    value: '3,430 supermarkets',
+    label: 'Daily opportunity is framed through the supermarket layer, not just through rail geometry.',
     tone: 'warm',
   },
 ]
 
 export const storyPanels: StoryPanelContent[] = [
   {
-    id: 'positioning',
-    navLabel: 'Coverage Map',
-    eyebrow: '',
-    title: 'National Reachability',
-    description: 'Select an origin city and departure window to instantly visualize travel times across Switzerland.',
+    id: 'transport-story',
+    topic: 'Transport Reachability',
+    panelKind: 'Story',
+    navLabel: 'Transport Story',
+    eyebrow: 'Transport Reachability',
+    title: 'Morning Reachability',
+    description:
+      'A fixed Lausanne departure at 08:00 reveals where the Swiss rail backbone is dense, where coverage thins out, and how national reach already differs before daily destinations enter the picture.',
     highlights: [
-      'Interactive real-time maps.',
-      'Travel times mapped via clear color gradients.',
-    ],
-    metrics: [
-      {
-        value: 'National coverage',
-        label: 'Explore intercity connections.',
-        tone: 'brand',
-      },
-      { value: 'Instant feedback', label: 'Click to discover.' },
-    ],
-    mediaVariant: 'reachability-map',
-    mediaCaption: 'Interactive Reachability Map. Scroll inside to zoom, drag to pan.',
-  },
-  {
-    id: 'feature-coverage',
-    navLabel: 'Lausanne Lab',
-    eyebrow: 'Lausanne',
-    title: 'Departure & Window',
-    description: 'Stay in Lausanne and adjust your departure time — 06:00, 08:00, or 18:00 — to observe the shift in national reachability. Budget your travel time to see which stations remain accessible and where the coverage begins to thin out.',
-    highlights: [
-      'Time-based comparative analysis.',
-      'Detailed regional distribution and isolated gaps.',
+      'A fixed morning case makes the national pattern legible before controls appear.',
+      'The same rail geometry will later be reused to explain retail opportunity.',
     ],
     metrics: [
       {
         value: '06:00 / 08:00 / 18:00',
-        label: 'Key departure times.',
+        label: 'The Lausanne lab already exposes the key departure windows.',
+        tone: 'brand',
+      },
+      {
+        value: 'Swiss scale',
+        label: 'Coverage is still evaluated as a national story, not as one city map.',
+        tone: 'neutral',
+      },
+      {
+        value: 'Story first',
+        label: 'The selected lens is here to frame the rest of the page before playgrounds take over.',
         tone: 'warm',
       },
-      { value: 'Station Focus', label: 'Local distribution data.' },
     ],
     mediaVariant: 'reachability-lab',
-    mediaCaption: 'Hover over plots to examine specific station reaches.',
+    mediaPreset: 'transport-story',
+    mediaCaption: 'Fixed on Lausanne so the first panel reads like an argument, not like a control surface.',
   },
   {
-    id: 'busiest-rail',
-    navLabel: 'Busiest Rail',
-    eyebrow: 'Network Density',
-    title: 'Swiss Rail Backbone',
-    description: 'Visualizing the busiest arteries and transfer hubs in the network based on daily train traffic. Drag the morning window open or shut to see how many different trains touch each platform, and where the crowd favourites start to dominate.',
+    id: 'transport-playground',
+    topic: 'Transport Reachability',
+    panelKind: 'Playground',
+    navLabel: 'Transport Playground',
+    eyebrow: 'Transport Reachability',
+    title: 'Explore the Network',
+    description:
+      'Switch origins, change departure times, and compare how much of Switzerland each major station can realistically pull into reach.',
     highlights: [
-      'Flows scaled to actual train volumes.',
-      'Highlighting the core network structure.',
+      'Origin and departure are the only two controls because the question is still singular.',
+      'The map keeps the same national frame so later retail panels feel like the same product.',
     ],
     metrics: [
-      { value: 'Network Load', label: 'Daily train density.', tone: 'brand' },
       {
-        value: 'Nodes & Edges',
-        label: 'Key transport hubs.',
+        value: '4 origins',
+        label: 'Lausanne, Bern, Geneve, and Zurich HB remain comparable anchor cases.',
+        tone: 'warm',
+      },
+      {
+        value: 'Travel-time gradient',
+        label: 'Color continues to encode how quickly the network opens up.',
         tone: 'neutral',
+      },
+      {
+        value: 'Interactive map',
+        label: 'Scroll inside to zoom and drag to pan without breaking the page rhythm.',
+        tone: 'brand',
+      },
+    ],
+    mediaVariant: 'reachability-map',
+    mediaPreset: 'transport-playground',
+    mediaCaption: 'Choose an origin, choose a departure, then read the national footprint.',
+  },
+  {
+    id: 'transport-load',
+    topic: 'Rail Backbone',
+    panelKind: 'Story',
+    navLabel: 'Rail Load',
+    eyebrow: 'Rail Backbone',
+    title: 'Network Load',
+    description:
+      'The busiest-station ranking makes the backbone visible from a different angle: not just where you can reach, but where rail traffic concentrates most strongly across the day.',
+    highlights: [
+      'The rail backbone is easier to read once movement intensity is separated from reachability.',
+      'A focused ranking view works better here than squeezing the chart into the map panel.',
+    ],
+    metrics: [
+      {
+        value: 'Window-based ranking',
+        label: 'Drag the morning window and compare how the concentration changes.',
+        tone: 'brand',
+      },
+      {
+        value: 'Core corridors',
+        label: 'The chart isolates the most heavily used parts of the network.',
+        tone: 'neutral',
+      },
+      {
+        value: 'Transport context',
+        label: 'This closes the transport section before retail begins.',
+        tone: 'warm',
       },
     ],
     mediaVariant: 'busiest-rail',
-    mediaCaption: 'Busiest Rail Network. Thicker lines indicate higher traffic.',
+    mediaPreset: 'transport-load',
+    mediaCaption: 'A dedicated rail-load view gives the ranking enough space to read as part of the transport story.',
+  },
+  {
+    id: 'retail-story',
+    topic: 'Retail Footprint',
+    panelKind: 'Story',
+    navLabel: 'Retail Story',
+    eyebrow: 'Retail Footprint',
+    title: 'Retail Footprint',
+    description:
+      'Supermarkets do not simply mirror rail intensity. The footprint clusters along the Swiss plateau, thickens around metropolitan corridors, and still reveals brand-specific gaps that a pure transport view would miss.',
+    highlights: [
+      'This panel stays on the stores themselves to establish retail as its own layer.',
+      'Migros and Coop overlap heavily, but not uniformly, across the national footprint.',
+    ],
+    metrics: [
+      {
+        value: '743 Migros',
+        label: 'Current OSM-based export used in the product layer.',
+        tone: 'neutral',
+      },
+      {
+        value: '943 Coop',
+        label: 'The Coop network is broader in the current national snapshot.',
+        tone: 'warm',
+      },
+      { value: 'Retail first', label: 'This topic asks where stores gather before asking who can reach them.', tone: 'brand' },
+    ],
+    mediaVariant: 'retail-density',
+    mediaPreset: 'retail-story',
+    mediaCaption: 'A national store footprint is enough to show that retail logic is related to transport, but not reducible to it.',
+  },
+  {
+    id: 'retail-playground',
+    topic: 'Retail Footprint',
+    panelKind: 'Playground',
+    navLabel: 'Retail Playground',
+    eyebrow: 'Retail Footprint',
+    title: 'Compare Store Networks',
+    description:
+      'Toggle Both, Migros, or Coop and compare how the national retail pattern shifts when one network drops out of view.',
+    highlights: [
+      'Brand filtering is the main interaction because the spatial comparison should stay immediate.',
+      'The control language deliberately matches the rest of SwissReach rather than turning into a dashboard.',
+    ],
+    metrics: [
+      {
+        value: 'Both / Migros / Coop',
+        label: 'Three states are enough for an MVP retail explorer.',
+        tone: 'brand',
+      },
+      {
+        value: 'Hover details',
+        label: 'Store names and source links remain available without cluttering the map.',
+        tone: 'neutral',
+      },
+      {
+        value: 'National frame',
+        label: 'The same Swiss boundary keeps this panel visually tied to the transport topic.',
+        tone: 'warm',
+      },
+    ],
+    mediaVariant: 'retail-density',
+    mediaPreset: 'retail-playground',
+    mediaCaption: 'Filtering the footprint is enough to make retail structure legible in three to five seconds.',
+  },
+  {
+    id: 'retail-access-story',
+    topic: 'Retail Access',
+    panelKind: 'Story',
+    navLabel: 'Retail Access Story',
+    eyebrow: 'Retail Access',
+    title: 'Retail Access',
+    description:
+      'Each rail station inherits a 30-minute supermarket count from the fixed 08:00 baseline, showing where strong network access really turns into daily retail choice and where it does not.',
+    highlights: [
+      'The baseline is explicit: these counts come from a fixed 08:00 departure export.',
+      'Opportunity is encoded as reachable supermarkets, not just as nearby track density.',
+    ],
+    metrics: [
+      {
+        value: '30-minute supermarkets',
+        label: 'The main retail-access metric used in the national story.',
+        tone: 'brand',
+      },
+      {
+        value: '08:00 only',
+        label: 'The UI states the time limit honestly instead of implying a live routing engine.',
+        tone: 'warm',
+      },
+      {
+        value: '1,663 stations',
+        label: 'Every point on the map is a logical rail station with exported POI counts.',
+        tone: 'neutral',
+      },
+    ],
+    mediaVariant: 'retail-access',
+    mediaPreset: 'retail-access-story',
+    mediaCaption: 'This view is fixed to the morning baseline, so the takeaway is about opportunity shape rather than arbitrary control changes.',
+  },
+  {
+    id: 'retail-access-playground',
+    topic: 'Retail Access',
+    panelKind: 'Playground',
+    navLabel: 'Retail Access Playground',
+    eyebrow: 'Retail Access',
+    title: 'Compare Reachable Opportunity',
+    description:
+      'Compare featured stations, supermarket counts within 30 minutes, and IKEA access within 60 minutes to contrast daily retail with sparse destination retail.',
+    highlights: [
+      'Featured station shortcuts keep exploration concrete and readable on a single screen.',
+      'Switching between supermarkets and IKEA makes “daily opportunity” versus “destination retail” intuitive.',
+    ],
+    metrics: [
+      {
+        value: 'Supermarkets / IKEA',
+        label: 'Two metrics, same map, different meanings of access.',
+        tone: 'brand',
+      },
+      {
+        value: 'Featured stations',
+        label: 'A small curated set is faster than a full search box in the first release.',
+        tone: 'neutral',
+      },
+      {
+        value: 'Same transport base',
+        label: 'Retail access stays downstream of the rail network rather than becoming a separate tool.',
+        tone: 'warm',
+      },
+    ],
+    mediaVariant: 'retail-access',
+    mediaPreset: 'retail-access-playground',
+    mediaCaption: 'The interaction remains honest and light: compare station cases, switch the retail lens, and keep the fixed morning baseline in view.',
+  },
+  {
+    id: 'brand-story',
+    topic: 'Brand Contrast',
+    panelKind: 'Story',
+    navLabel: 'Brand Story',
+    eyebrow: 'Brand Contrast',
+    title: 'Brand Contrast',
+    description:
+      'Migros and Coop overlap strongly in major corridors, but the balance is not flat. Comparison mode highlights where one network broadens everyday choice and where the national retail story is effectively being carried by the other.',
+    highlights: [
+      'This is still a geography question, not a market-share dashboard.',
+      'Difference mode is most useful once the user has already seen the full footprint and the access layer.',
+    ],
+    metrics: [
+      {
+        value: 'Brand-aware reading',
+        label: '“How many stores?” and “which network?” are not interchangeable questions.',
+        tone: 'brand',
+      },
+      {
+        value: 'Shared corridors',
+        label: 'Overlap is highest where national population and rail intensity already concentrate.',
+        tone: 'neutral',
+      },
+      {
+        value: 'Uneven margins',
+        label: 'Regional imbalances still matter once one brand is filtered out.',
+        tone: 'warm',
+      },
+    ],
+    mediaVariant: 'retail-density',
+    mediaPreset: 'brand-story',
+    mediaCaption: 'Difference mode is a retail reading of the same Swiss surface, not a detached appendix.',
+  },
+  {
+    id: 'brand-playground',
+    topic: 'Brand Contrast',
+    panelKind: 'Playground',
+    navLabel: 'Brand Playground',
+    eyebrow: 'Brand Contrast',
+    title: 'Explore Brand Differences',
+    description:
+      'Flip between Both, Migros, Coop, and Difference to see how brand structure changes the geography of everyday retail.',
+    highlights: [
+      'The same component handles the comparison to avoid inventing a second visual language.',
+      'Ending on an exploratory brand panel makes the retail line feel like a main story rather than a footnote.',
+    ],
+    metrics: [
+      {
+        value: 'Difference mode',
+        label: 'The strongest contrast view lives in the final retail panel.',
+        tone: 'brand',
+      },
+      {
+        value: 'Single-map compare',
+        label: 'No separate page, no detached chart, just one continuous product narrative.',
+        tone: 'neutral',
+      },
+      {
+        value: 'Retail closes the loop',
+        label: 'Transport explains connection; brand structure explains which choices that connection unlocks.',
+        tone: 'warm',
+      },
+    ],
+    mediaVariant: 'retail-density',
+    mediaPreset: 'brand-playground',
+    mediaCaption: 'Brand switching is the last step in the sequence because it depends on the transport and retail layers that came before it.',
   },
 ]

--- a/frontend/src/content/productStory.ts
+++ b/frontend/src/content/productStory.ts
@@ -94,7 +94,7 @@ export const storyPanels: StoryPanelContent[] = [
     ],
     mediaVariant: 'reachability-lab',
     mediaPreset: 'transport-story',
-    mediaCaption: 'Fixed on Lausanne so the first panel reads like an argument, not like a control surface.',
+    mediaCaption: 'Lausanne at 08:00 provides a consistent morning baseline for the national map.',
   },
   {
     id: 'transport-playground',
@@ -128,7 +128,7 @@ export const storyPanels: StoryPanelContent[] = [
     ],
     mediaVariant: 'reachability-map',
     mediaPreset: 'transport-playground',
-    mediaCaption: 'Choose an origin, choose a departure, then read the national footprint.',
+    mediaCaption: 'Switch origin and departure to compare the national reachability footprint.',
   },
   {
     id: 'transport-load',
@@ -162,7 +162,7 @@ export const storyPanels: StoryPanelContent[] = [
     ],
     mediaVariant: 'busiest-rail',
     mediaPreset: 'transport-load',
-    mediaCaption: 'A dedicated rail-load view gives the ranking enough space to read as part of the transport story.',
+    mediaCaption: 'Rail load is shown separately so the ranking stays readable at a glance.',
   },
   {
     id: 'retail-story',
@@ -192,7 +192,7 @@ export const storyPanels: StoryPanelContent[] = [
     ],
     mediaVariant: 'retail-density',
     mediaPreset: 'retail-story',
-    mediaCaption: 'A national store footprint is enough to show that retail logic is related to transport, but not reducible to it.',
+    mediaCaption: 'National retail density follows its own spatial pattern across Switzerland.',
   },
   {
     id: 'retail-playground',
@@ -226,7 +226,7 @@ export const storyPanels: StoryPanelContent[] = [
     ],
     mediaVariant: 'retail-density',
     mediaPreset: 'retail-playground',
-    mediaCaption: 'Filtering the footprint is enough to make retail structure legible in three to five seconds.',
+    mediaCaption: 'Brand filters reveal how the national supermarket footprint changes by network.',
   },
   {
     id: 'retail-access-story',
@@ -260,7 +260,7 @@ export const storyPanels: StoryPanelContent[] = [
     ],
     mediaVariant: 'retail-access',
     mediaPreset: 'retail-access-story',
-    mediaCaption: 'This view is fixed to the morning baseline, so the takeaway is about opportunity shape rather than arbitrary control changes.',
+    mediaCaption: 'Retail access is shown on a fixed 08:00 baseline.',
   },
   {
     id: 'retail-access-playground',
@@ -294,7 +294,7 @@ export const storyPanels: StoryPanelContent[] = [
     ],
     mediaVariant: 'retail-access',
     mediaPreset: 'retail-access-playground',
-    mediaCaption: 'The interaction remains honest and light: compare station cases, switch the retail lens, and keep the fixed morning baseline in view.',
+    mediaCaption: 'Compare stations and retail types on the same published morning baseline.',
   },
   {
     id: 'brand-story',
@@ -328,7 +328,7 @@ export const storyPanels: StoryPanelContent[] = [
     ],
     mediaVariant: 'retail-density',
     mediaPreset: 'brand-story',
-    mediaCaption: 'Difference mode is a retail reading of the same Swiss surface, not a detached appendix.',
+    mediaCaption: 'Difference mode highlights where one supermarket network is denser than the other.',
   },
   {
     id: 'brand-playground',
@@ -362,6 +362,6 @@ export const storyPanels: StoryPanelContent[] = [
     ],
     mediaVariant: 'retail-density',
     mediaPreset: 'brand-playground',
-    mediaCaption: 'Brand switching is the last step in the sequence because it depends on the transport and retail layers that came before it.',
+    mediaCaption: 'Switch between Both, Migros, Coop, and Difference to compare brand structure directly.',
   },
 ]

--- a/frontend/src/styles/base.css
+++ b/frontend/src/styles/base.css
@@ -23,6 +23,8 @@
   --content-width: min(var(--content-max-width), calc(100vw - (var(--page-inline-padding) * 2)));
   --section-gap: clamp(5rem, 7vw, 8rem);
   --copy-width: 48rem;
+  --section-top-padding: clamp(5.8rem, 9vw, 7.4rem);
+  --section-bottom-padding: clamp(2.8rem, 5vw, 4.2rem);
   font-family: var(--swissreach-font-sans);
   font-synthesis: none;
   text-rendering: optimizeLegibility;
@@ -244,6 +246,8 @@ button {
     --page-inline-padding: 10px;
     --radius-shell: 24px;
     --radius-card: 20px;
+    --section-top-padding: 8.8rem;
+    --section-bottom-padding: 2.2rem;
   }
 
   .section-text {

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -57,6 +57,20 @@ function copyDocsFonts(): Plugin {
   }
 }
 
+function copyDocsData(): Plugin {
+  const docsData = path.resolve(fileURLToPath(new URL('../docs/public/data', import.meta.url)))
+  return {
+    name: 'copy-docs-data',
+    closeBundle() {
+      const distDir = path.resolve(fileURLToPath(new URL('./dist', import.meta.url)))
+      const dataOutDir = path.join(distDir, 'data')
+      fs.mkdirSync(distDir, { recursive: true })
+      fs.rmSync(dataOutDir, { recursive: true, force: true })
+      fs.cpSync(docsData, dataOutDir, { recursive: true })
+    },
+  }
+}
+
 const docsPublicDir = path.resolve(fileURLToPath(new URL('../docs/public', import.meta.url)))
 
 // https://vite.dev/config/
@@ -66,6 +80,7 @@ export default defineConfig({
     vueDevTools(),
     serveDocsPublic(),
     copyDocsFonts(),
+    copyDocsData(),
   ],
   server: {
     fs: {


### PR DESCRIPTION
## Summary
- expand the frontend story flow with dedicated retail density, retail access, and rail load panels
- add new retail visualizations, including a hexbin-style supermarket density view and brand comparison modes
- tighten the product-page copy, hero framing, and section navigation so the demo reads more like a finished experience

## Testing
- cd frontend && npm run build